### PR TITLE
わざとデプロイ失敗させる

### DIFF
--- a/Try-Deploy-App/README.md
+++ b/Try-Deploy-App/README.md
@@ -8,7 +8,7 @@
 ## OepnAPIファイルをS3バケットに格納する
 
 ```bash
-aws s3 cp openapi.yaml s3://aws-sam-cli-managed-default-samclisourcebucket-1t8vcnv9f5use/Try-Deploy-App/openapi.yaml
+aws s3 cp openapi.yaml s3://aws-sam-cli-managed-default-samclisourcebucket-1t8vcnv9f5use/Try-Deploy-App/api/openapi.yaml
 ```
 
 ## デプロイする

--- a/Try-Deploy-App/openapi.yaml
+++ b/Try-Deploy-App/openapi.yaml
@@ -17,8 +17,8 @@ paths:
         type: aws_proxy
         uri:
           'Fn::Sub': >-
-            arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HelloWorldFunction.Arn}/invocations
-        httpMethod: POST
+            arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SampleFunction.Arn}/invocations
+        httpMethod: GET
         responses:
           default:
             statusCode: 200

--- a/Try-Deploy-App/template.yaml
+++ b/Try-Deploy-App/template.yaml
@@ -8,7 +8,7 @@ Parameters:
 
 Globals:
   Function:
-    Timeout: 10
+    Timeout: 3
     LoggingConfig:
       LogFormat: JSON
 
@@ -29,7 +29,7 @@ Resources:
     Properties:
       CodeUri: hello_world/
       Handler: app.lambda_handler
-      Runtime: python3.11
+      Runtime: python3.8
       Architectures:
         - x86_64
       Policies:


### PR DESCRIPTION
このPull request（のブランチ）の内容を提供する。

つまり、ベースとなっているブランチ（main）の内容が正解になる。

---

なお、本内容以外にも下記があります。

- README.md に `sam build` コマンドの記述がないので、Lambda実行時に失敗する（デプロイパッケージにライブラリがないため）
- `sam build` に `--use-container` オプションをつけ忘れると、Lambda実行時に失敗する（アーキテクチャ不一致）
- （本筋には関係ないけど）`template.yaml`の`Outputs`の`Value`が間違っているので、正しいAPIエンドポイントを得られない（ので、他の手段で探しに行く必要がある）